### PR TITLE
Introduce -noSortFields option

### DIFF
--- a/src/main/java/net/sourceforge/pldoc/PLDoc.java
+++ b/src/main/java/net/sourceforge/pldoc/PLDoc.java
@@ -1128,6 +1128,7 @@ public class PLDoc
       resLoader.getResourceStream("unit.xsl")));
     //Have to pass in Absolute location of output directory in order to avoid problems with spaces in paths
     transformer.setParameter("targetFolder", settings.getOutputDirectory().getAbsolutePath() + File.separator );
+    transformer.setParameter("sortFields", Boolean.toString(settings.isSortFields()));
     if ( settings.isSaveSourceCode() ) // Generate links to source code 
     {
       transformer.setParameter("sourceRootFolder", '.' );

--- a/src/main/java/net/sourceforge/pldoc/Settings.java
+++ b/src/main/java/net/sourceforge/pldoc/Settings.java
@@ -56,6 +56,7 @@ public class Settings
   private boolean keywordsDefaultcase = true; //SRT 20110419
   private boolean keywordsUppercase = false; //SRT 20110419
   private boolean keywordsLowercase = false; //SRT 20110419
+  private boolean sortFields = true;
   // by default, assume system default encoding for all input files
   private String inputEncoding = System.getProperty("file.encoding");
   // we cannot yet set output encoding dynamically, because of XSLs
@@ -105,6 +106,7 @@ public class Settings
     "-keywordsdefaultcase      Convert all names to defaultcase [default true]\n" +
     "-keywordsuppercase        Convert all keywords to uppercase\n" +
     "-keywordslowercase        Convert all keywords to lowercase\n" +
+    "-noSortFields             Do not sort fields\n" +
     "-stylesheetfile <path>    File to change style of the generated document [default: defaultstylesheet.css]\n" +
     "-definesfile <path>       File containing SQL*Plus-style variable substitutions [default: none], for example:\n" +
     "                          &myvar1=123456\n" +
@@ -306,6 +308,10 @@ public class Settings
         // consume  "-keywordslowercase"
         this.keywordsLowercase = true;
       }
+      else if (arg.equalsIgnoreCase("-nosortfields")) {
+        // consume  "-noSortFields"
+        this.sortFields = false;
+      }
       else if (arg.equalsIgnoreCase("-inputencoding")) {
         // consume  "-inputencoding"
         if(!it.hasNext()) {
@@ -458,6 +464,9 @@ public class Settings
   public void setKeywordsLowercase(boolean keywordsLowercase) {
           this.keywordsLowercase = keywordsLowercase;
   }
+  public void setSortFields(boolean sortFields) {
+          this.sortFields = sortFields;
+  }
   public void setInputEncoding(String inputEncoding) {
           this.inputEncoding = inputEncoding;
   }
@@ -584,6 +593,10 @@ public class Settings
 
   public boolean isKeywordsLowercase() {
     return keywordsLowercase;
+  }
+
+  public boolean isSortFields() {
+    return sortFields;
   }
 
   public String getInputEncoding() {


### PR DESCRIPTION
Object types (CREATE TYPE) are created with a default constructor
matching all the fields in the type. Sorting the fields in a type
makes it impossible to see the default constructor.
- Small refactoring of unit.xsl, to ease the conditional sorting
- A new xsl:parameter $sortFields to control sorting
- Optional use of xsl:sort, depending on the $sortField parameter
- A new property "sortFields" in Settings, defaulting to true
- A new command line option "-noSortFields" to disable sorting
